### PR TITLE
init: Remove creation and mounting of /config from init.yoshino.usb.rc

### DIFF
--- a/config/init/init.yoshino.usb.rc
+++ b/config/init/init.yoshino.usb.rc
@@ -41,9 +41,6 @@ on post-fs
     chmod 0660 /config/usb_gadget/g1/functions/gsi.rndis/linux_support
 
 on charger
-    mkdir /config 0770 shell shell
-    mount configfs none /config
-
     mkdir /config/usb_gadget/g1 0770 shell shell
     mkdir /config/usb_gadget/g1/strings/0x409 0770 shell shell
 
@@ -93,9 +90,6 @@ on charger
 on boot
     mkdir /dev/usb-ffs 0770 shell shell
     mkdir /dev/usb-ffs/adb 0770 shell shell
-
-    mkdir /config 0770 shell shell
-    mount configfs none /config
 
     mkdir /config/usb_gadget/g1 0770 shell shell
     mkdir /config/usb_gadget/g1/strings/0x409 0770 shell shell


### PR DESCRIPTION
This is handled by the init.rc in the rootdir.

Also, shell:shell is the wrong owner/group (should be root:root) and causes sdcardfs to fail generating app-specific folder leading to all sort of storage permission weirdness.

Change-Id: Id15d0982de8741f93d4eee164b2d6c1a03497f4a